### PR TITLE
suppress benign warning

### DIFF
--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -325,7 +325,10 @@ bool CFREDDoc::load_mission(const char *pathname, int flags) {
 		// double check the used pool is empty
 		for (j = 0; j < weapon_info_size(); j++) {
 			if (used_pool[j] != 0) {
-				Warning(LOCATION, "%s is used in wings of team %d but was not in the loadout. Fixing now", Weapon_info[j].name, i + 1);
+				// suppress the warning when importing an X-Wing mission, since this is as good a place as any to fix the loadout
+				if (!(flags & MPF_IMPORT_XWI)) {
+					Warning(LOCATION, "%s is used in wings of team %d but was not in the loadout. Fixing now", Weapon_info[j].name, i + 1);
+				}
 
 				// add the weapon as a new entry
 				Team_data[i].weaponry_pool[Team_data[i].num_weapon_choices] = j;


### PR DESCRIPTION
Rather than redundantly handle the loadout when objects are being created, let's just allow the importer to fix the weaponry pool here.