### PR TITLE
Limit space objects to 64

### DIFF
--- a/code/mission/import/xwingmissionparse.cpp
+++ b/code/mission/import/xwingmissionparse.cpp
@@ -826,6 +826,7 @@ void parse_xwi_objectgroup(mission *pm, const XWingMission *xwim, const XWMObjec
 		break;
 	}
 
+	// Check that the Xwing game engine object limit is not exceeded with this object group
 	if (object_count + (number_of_objects * number_of_objects) > MAX_SPACE_OBJECTS) 
 		return;
 	object_count += (number_of_objects * number_of_objects);
@@ -972,11 +973,9 @@ void parse_xwi_mission(mission *pm, const XWingMission *xwim)
 	for (const auto &fg : xwim->flightgroups)
 		parse_xwi_flightgroup(pm, xwim, &fg);
 
-	// load objects - up to the maximum number of objects allowed by the XWing engine
+	// load object groups
 	int object_count = 0;
 	for (const auto& obj : xwim->objects) {
-		if (object_count >= MAX_SPACE_OBJECTS)
-			break;
 		parse_xwi_objectgroup(pm, xwim, &obj, object_count); 
 	}
 }

--- a/code/mission/import/xwingmissionparse.cpp
+++ b/code/mission/import/xwingmissionparse.cpp
@@ -826,6 +826,10 @@ void parse_xwi_objectgroup(mission *pm, const XWingMission *xwim, const XWMObjec
 		break;
 	}
 
+	if (object_count + (number_of_objects * number_of_objects) > MAX_SPACE_OBJECTS) 
+		return;
+	object_count += (number_of_objects * number_of_objects);
+
 	// Copy objects in Parse_objects to set for name checking below
 	// This only needs to be done fully once per object group then can be added to after each new object
 	SCP_set<SCP_string> objectNameSet;
@@ -901,10 +905,6 @@ void parse_xwi_objectgroup(mission *pm, const XWingMission *xwim, const XWMObjec
 			pobj.flags.set(Mission::Parse_Object_Flags::SF_Hide_ship_name);	// space objects in X-Wing don't really have names
 
 			Parse_objects.push_back(pobj);
-			
-			object_count++;
-			if (object_count >= MAX_SPACE_OBJECTS)
-				return;
 		}
 	}
 }	

--- a/code/mission/import/xwingmissionparse.cpp
+++ b/code/mission/import/xwingmissionparse.cpp
@@ -975,9 +975,8 @@ void parse_xwi_mission(mission *pm, const XWingMission *xwim)
 
 	// load object groups
 	int object_count = 0;
-	for (const auto& obj : xwim->objects) {
+	for (const auto& obj : xwim->objects) 
 		parse_xwi_objectgroup(pm, xwim, &obj, object_count); 
-	}
 }
 
 void post_process_xwi_mission(mission *pm, const XWingMission *xwim)


### PR DESCRIPTION
Despite some mission files containing over 100 space objects, only 64 are loaded in the mission. This should be reflected in the FRED import too. Therefore place a limit of 64 objects to be imported into FRED.