### PR TITLE
use fast reload for XWI import

### DIFF
--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -640,7 +640,7 @@ void CFREDDoc::OnFileImportXWI()
 		strcpy_s(xwi_path, xwi_path_mfc);
 
 		// load mission into memory
-		if (!load_mission(xwi_path, MPF_IMPORT_XWI))
+		if (!load_mission(xwi_path, MPF_IMPORT_XWI | MPF_FAST_RELOAD))
 			continue;
 
 		// get filename


### PR DESCRIPTION
When importing missions, FRED should use fast reload.  It already does it for importing FS1 missions, so this adds it for XWI missions as well.