### PR TITLE
Set Default Team

### DIFF
--- a/code/mission/import/xwingmissionparse.cpp
+++ b/code/mission/import/xwingmissionparse.cpp
@@ -326,32 +326,49 @@ int xwi_determine_ship_class(const XWMFlightGroup *fg)
 	return base_class;
 }
 
+const char* xwi_determine_default_team(const XWMFlightGroup* fg)
+{
+	switch (fg->flightGroupType) {
+	case XWMFlightGroupType::fg_X_Wing:
+	case XWMFlightGroupType::fg_Y_Wing:
+	case XWMFlightGroupType::fg_A_Wing:
+	case XWMFlightGroupType::fg_B_Wing:
+	case XWMFlightGroupType::fg_Calamari_Cruiser:
+	case XWMFlightGroupType::fg_Nebulon_B_Frigate:
+		return "Friendly";
+	case XWMFlightGroupType::fg_TIE_Fighter:
+	case XWMFlightGroupType::fg_TIE_Interceptor:
+	case XWMFlightGroupType::fg_TIE_Bomber:
+	case XWMFlightGroupType::fg_Gunboat:
+	case XWMFlightGroupType::fg_Imperial_Star_Destroyer:
+	case XWMFlightGroupType::fg_TIE_Advanced:
+	case XWMFlightGroupType::fg_Transport:
+		return "Hostile";
+	case XWMFlightGroupType::fg_Shuttle:
+	case XWMFlightGroupType::fg_Tug:
+	case XWMFlightGroupType::fg_Container:
+	case XWMFlightGroupType::fg_Freighter:
+	case XWMFlightGroupType::fg_Corellian_Corvette:
+		return "Civilian";
+	default:
+		break;
+	}
+
+	return 0;
+}
+
 const char *xwi_determine_team(const XWingMission *xwim, const XWMFlightGroup *fg, const ship_info *sip)
 {
 	SCP_UNUSED(sip);
 
-	auto player_iff = xwim->flightgroups[Player_flight_group].craftIFF;
-
 	if (fg->craftIFF == XWMCraftIFF::iff_imperial)
-	{
-		if (player_iff == XWMCraftIFF::iff_imperial)
-			return "Friendly";
-		if (player_iff == XWMCraftIFF::iff_rebel)
 			return "Hostile";
-	}
-
 	if (fg->craftIFF == XWMCraftIFF::iff_rebel)
-	{
-		if (player_iff == XWMCraftIFF::iff_imperial)
-			return "Hostile";
-		if (player_iff == XWMCraftIFF::iff_rebel)
 			return "Friendly";
-	}
-
 	if (fg->craftIFF == XWMCraftIFF::iff_neutral)
 		return "Civilian";
 
-	return nullptr;
+	return xwi_determine_default_team(fg);
 }
 
 int xwi_lookup_cargo(const char *cargo_name)

--- a/code/mission/import/xwingmissionparse.cpp
+++ b/code/mission/import/xwingmissionparse.cpp
@@ -354,7 +354,7 @@ const char* xwi_determine_default_team(const XWMFlightGroup* fg)
 		break;
 	}
 
-	return 0;
+	return nullptr;
 }
 
 const char *xwi_determine_team(const XWingMission *xwim, const XWMFlightGroup *fg, const ship_info *sip)

--- a/code/mission/import/xwingmissionparse.cpp
+++ b/code/mission/import/xwingmissionparse.cpp
@@ -326,37 +326,6 @@ int xwi_determine_ship_class(const XWMFlightGroup *fg)
 	return base_class;
 }
 
-const char* xwi_determine_default_team(const XWMFlightGroup* fg)
-{
-	switch (fg->flightGroupType) {
-	case XWMFlightGroupType::fg_X_Wing:
-	case XWMFlightGroupType::fg_Y_Wing:
-	case XWMFlightGroupType::fg_A_Wing:
-	case XWMFlightGroupType::fg_B_Wing:
-	case XWMFlightGroupType::fg_Calamari_Cruiser:
-	case XWMFlightGroupType::fg_Nebulon_B_Frigate:
-		return "Friendly";
-	case XWMFlightGroupType::fg_TIE_Fighter:
-	case XWMFlightGroupType::fg_TIE_Interceptor:
-	case XWMFlightGroupType::fg_TIE_Bomber:
-	case XWMFlightGroupType::fg_Gunboat:
-	case XWMFlightGroupType::fg_Imperial_Star_Destroyer:
-	case XWMFlightGroupType::fg_TIE_Advanced:
-	case XWMFlightGroupType::fg_Transport:
-		return "Hostile";
-	case XWMFlightGroupType::fg_Shuttle:
-	case XWMFlightGroupType::fg_Tug:
-	case XWMFlightGroupType::fg_Container:
-	case XWMFlightGroupType::fg_Freighter:
-	case XWMFlightGroupType::fg_Corellian_Corvette:
-		return "Civilian";
-	default:
-		break;
-	}
-
-	return nullptr;
-}
-
 const char *xwi_determine_team(const XWingMission *xwim, const XWMFlightGroup *fg, const ship_info *sip)
 {
 	SCP_UNUSED(sip);
@@ -368,7 +337,33 @@ const char *xwi_determine_team(const XWingMission *xwim, const XWMFlightGroup *f
 	if (fg->craftIFF == XWMCraftIFF::iff_neutral)
 		return "Civilian";
 
-	return xwi_determine_default_team(fg);
+	switch (fg->flightGroupType) {
+		case XWMFlightGroupType::fg_X_Wing:
+		case XWMFlightGroupType::fg_Y_Wing:
+		case XWMFlightGroupType::fg_A_Wing:
+		case XWMFlightGroupType::fg_B_Wing:
+		case XWMFlightGroupType::fg_Calamari_Cruiser:
+		case XWMFlightGroupType::fg_Nebulon_B_Frigate:
+			return "Friendly";
+		case XWMFlightGroupType::fg_TIE_Fighter:
+		case XWMFlightGroupType::fg_TIE_Interceptor:
+		case XWMFlightGroupType::fg_TIE_Bomber:
+		case XWMFlightGroupType::fg_Gunboat:
+		case XWMFlightGroupType::fg_Imperial_Star_Destroyer:
+		case XWMFlightGroupType::fg_TIE_Advanced:
+		case XWMFlightGroupType::fg_Transport:
+			return "Hostile";
+		case XWMFlightGroupType::fg_Shuttle:
+		case XWMFlightGroupType::fg_Tug:
+		case XWMFlightGroupType::fg_Container:
+		case XWMFlightGroupType::fg_Freighter:
+		case XWMFlightGroupType::fg_Corellian_Corvette:
+			return "Civilian";
+		default:
+			break;
+	}
+
+	return nullptr;
 }
 
 int xwi_lookup_cargo(const char *cargo_name)


### PR DESCRIPTION
Set the default teams for each craft to match the XWing game rather than the default teams for FotG. Remove check to compare ship team with player assigned team as XWing does not assign a team to the player (it is just the default, which is always Rebel). Rebels are always friendly and Imperials always hostile.