### PR TITLE
update player flags when importing a mission

### DIFF
--- a/code/mission/import/xwingmissionparse.cpp
+++ b/code/mission/import/xwingmissionparse.cpp
@@ -619,8 +619,6 @@ void parse_xwi_flightgroup(mission *pm, const XWingMission *xwim, const XWMFligh
 				{
 					Warning(LOCATION, "This mission specifies multiple player starting ships.  Skipping %s.", Player_start_shipname);
 					prev_player_pobjp->flags.remove(Mission::Parse_Object_Flags::OF_Player_start);
-					prev_player_pobjp->flags.remove(Mission::Parse_Object_Flags::SF_Cargo_known);
-					prev_player_pobjp->flags.remove(Mission::Parse_Object_Flags::SF_Cannot_perform_scan);
 					Player_starts--;
 				}
 				else
@@ -629,8 +627,6 @@ void parse_xwi_flightgroup(mission *pm, const XWingMission *xwim, const XWMFligh
 
 			strcpy_s(Player_start_shipname, pobj.name);
 			pobj.flags.set(Mission::Parse_Object_Flags::OF_Player_start);
-			pobj.flags.set(Mission::Parse_Object_Flags::SF_Cargo_known);
-			pobj.flags.set(Mission::Parse_Object_Flags::SF_Cannot_perform_scan);
 			Player_starts++;
 		}
 


### PR DESCRIPTION
The "cannot-perform-scan" flag is most appropriately handled by the XWI script, since that script also handles the inspecting/identifying gameplay mechanic.  So, when setting or changing the player start, only set or change the player start flag.