### PR TITLE
xwing import: implement BRF briefing conversion

### DIFF
--- a/code/mission/import/xwingmissionparse.cpp
+++ b/code/mission/import/xwingmissionparse.cpp
@@ -3,8 +3,10 @@
 #include "mission/missiongoals.h"
 #include "mission/missionmessage.h"
 #include "missionui/redalert.h"
+#include "mod_table/mod_table.h"
 #include "nebula/neb.h"
 #include "parse/parselo.h"
+#include "render/3d.h"
 #include "ship/ship.h"
 #include "species_defs/species_defs.h"
 #include "starfield/starfield.h"
@@ -1387,40 +1389,935 @@ void post_process_xwi_mission(mission *pm, const XWingMission *xwim)
 	}
 }
 
+// ============================================================================
+// .BRF briefing -> FSO briefing conversion
+// ============================================================================
+
+static bool xwi_brf_is_ship_type(XWMBrfIconType t)
+{
+	switch (t)
+	{
+		case XWMBrfIconType::bi_X_Wing:
+		case XWMBrfIconType::bi_Y_Wing:
+		case XWMBrfIconType::bi_A_Wing:
+		case XWMBrfIconType::bi_TIE_Fighter:
+		case XWMBrfIconType::bi_TIE_Interceptor:
+		case XWMBrfIconType::bi_TIE_Bomber:
+		case XWMBrfIconType::bi_Assault_Gunboat:
+		case XWMBrfIconType::bi_Transport:
+		case XWMBrfIconType::bi_Shuttle:
+		case XWMBrfIconType::bi_Tug:
+		case XWMBrfIconType::bi_Container:
+		case XWMBrfIconType::bi_Freighter:
+		case XWMBrfIconType::bi_Calamari_Cruiser:
+		case XWMBrfIconType::bi_Nebulon_B_Frigate:
+		case XWMBrfIconType::bi_Corellian_Corvette:
+		case XWMBrfIconType::bi_Star_Destroyer:
+		case XWMBrfIconType::bi_TIE_Advanced:
+		case XWMBrfIconType::bi_B_Wing:
+			return true;
+		default:
+			return false;
+	}
+}
+
+static bool xwi_brf_event_implies_map(XWMBrfEventOpcode op)
+{
+	switch (op)
+	{
+		case XWMBrfEventOpcode::op_MoveMap:
+		case XWMBrfEventOpcode::op_ZoomMap:
+		case XWMBrfEventOpcode::op_ClearFGTags:
+		case XWMBrfEventOpcode::op_FGTag1:
+		case XWMBrfEventOpcode::op_FGTag2:
+		case XWMBrfEventOpcode::op_FGTag3:
+		case XWMBrfEventOpcode::op_FGTag4:
+		case XWMBrfEventOpcode::op_ClearTextTags:
+		case XWMBrfEventOpcode::op_TextTag1:
+		case XWMBrfEventOpcode::op_TextTag2:
+		case XWMBrfEventOpcode::op_TextTag3:
+		case XWMBrfEventOpcode::op_TextTag4:
+			return true;
+		default:
+			return false;
+	}
+}
+
+static bool is_brf_map_page(const XWingBriefing *xwBrief, const XWMBrfPage &page)
+{
+	// Primary signal: page's viewport set has the Map viewport (index 4) visible
+	if (page.pageType >= 0 && page.pageType < (int)xwBrief->viewportSets.size())
+		return xwBrief->viewportSets[page.pageType].viewports[4].visible;
+
+	// Fallback: any map-affecting event present implies a map page
+	for (const auto &event : page.events)
+	{
+		if (xwi_brf_event_implies_map(event.opcode))
+			return true;
+	}
+	return false;
+}
+
+static int xwi_find_navbuoy_ship_class()
+{
+	for (auto it = Ship_info.cbegin(); it != Ship_info.cend(); ++it)
+	{
+		if (it->flags[Ship::Info_Flags::Navbuoy])
+			return (int)std::distance(Ship_info.cbegin(), it);
+	}
+	return -1;
+}
+
+// Pattern lifted from FRED's briefing_editor_dlg::OnMakeIcon (briefingeditordlg.cpp:1102-1144).
+static int xwi_pick_briefing_icon_type(int ship_class, int wing_count)
+{
+	if (ship_class < 0 || ship_class >= (int)Ship_info.size())
+		return ICON_WAYPOINT;
+
+	auto sip = &Ship_info[ship_class];
+	bool wing = (wing_count > 1);
+
+	if (sip->flags[Ship::Info_Flags::Knossos_device])  return ICON_KNOSSOS_DEVICE;
+	if (sip->flags[Ship::Info_Flags::Corvette])        return ICON_CORVETTE;
+	if (sip->flags[Ship::Info_Flags::Gas_miner])       return ICON_GAS_MINER;
+	if (sip->flags[Ship::Info_Flags::Supercap])        return ICON_SUPERCAP;
+	if (sip->flags[Ship::Info_Flags::Sentrygun])       return ICON_SENTRYGUN;
+	if (sip->flags[Ship::Info_Flags::Awacs])           return ICON_AWACS;
+	if (sip->flags[Ship::Info_Flags::Cargo])           return wing ? ICON_CARGO_WING : ICON_CARGO;
+	if (sip->flags[Ship::Info_Flags::Support])         return ICON_SUPPORT_SHIP;
+	if (sip->flags[Ship::Info_Flags::Fighter])         return wing ? ICON_FIGHTER_WING : ICON_FIGHTER;
+	if (sip->flags[Ship::Info_Flags::Bomber])          return wing ? ICON_BOMBER_WING : ICON_BOMBER;
+	if (sip->flags[Ship::Info_Flags::Freighter])       return wing ? ICON_FREIGHTER_WING_NO_CARGO : ICON_FREIGHTER_NO_CARGO;
+	if (sip->flags[Ship::Info_Flags::Cruiser])         return wing ? ICON_CRUISER_WING : ICON_CRUISER;
+	if (sip->flags[Ship::Info_Flags::Transport])       return wing ? ICON_TRANSPORT_WING : ICON_TRANSPORT;
+	if (sip->flags[Ship::Info_Flags::Capital] || sip->flags[Ship::Info_Flags::Drydock]) return ICON_CAPITAL;
+	if (sip->flags[Ship::Info_Flags::Navbuoy])         return ICON_WAYPOINT;
+	return ICON_ASTEROID_FIELD;
+}
+
+// 2D briefing-map coord (in km) -> FSO 3D world position (in meters), with the
+// Y/Z swap used throughout this importer.  Per the spec, the BRF Y axis is
+// usually inverted from the XWI Y axis, so we negate Y to put briefing icons
+// in the same world frame as the .XWI-derived ship positions (which use the
+// straight XWI Y -> FSO Z mapping at xwingmissionparse.cpp:534).  BRF Z
+// (altitude) is intentionally ignored: the briefing camera is dead overhead,
+// so altitude would only affect perspective foreshortening, not screen
+// position, and X-Wing renders all icons on a flat map regardless.
+static vec3d brf_map_pos(float x_km, float y_km)
+{
+	auto pos = vm_vec_new(x_km, 0.0f, -y_km);
+	vm_vec_scale(&pos, 1000);
+	return pos;
+}
+
+// Build a "looking straight down at the XZ plane" orientation.  In FSO,
+// fvec.y = -sin(pitch) (see sincos_2_matrix at vecmat.cpp:726), so pitch =
+// +PI_2 yields fvec = (0, -1, 0) -- camera looking in -Y, which is what we
+// want when the camera is positioned at +Y above the icon plane.
+static void make_overhead_orient(matrix *orient)
+{
+	angles a;
+	a.p = PI_2;
+	a.b = 0;
+	a.h = 0;
+	vm_angles_2_matrix(orient, &a);
+}
+
+// Bounding box of an icon coord set (in km).  Returns false if the set is empty.
+static bool brf_icon_bbox(const std::vector<XWMBrfCoordinate> &coords, float *min_x, float *max_x, float *min_y, float *max_y, float *center_x, float *center_y)
+{
+	if (coords.empty())
+		return false;
+	*min_x = *max_x = coords[0].x;
+	*min_y = *max_y = coords[0].y;
+	for (size_t i = 1; i < coords.size(); i++)
+	{
+		if (coords[i].x < *min_x) *min_x = coords[i].x;
+		if (coords[i].x > *max_x) *max_x = coords[i].x;
+		if (coords[i].y < *min_y) *min_y = coords[i].y;
+		if (coords[i].y > *max_y) *max_y = coords[i].y;
+	}
+	*center_x = 0.5f * (*min_x + *max_x);
+	*center_y = 0.5f * (*min_y + *max_y);
+	return true;
+}
+
+static void compute_static_overview_camera(vec3d *out_pos, matrix *out_orient, const std::vector<XWMBrfCoordinate> &coords)
+{
+	float min_x, max_x, min_y, max_y, cx, cy;
+	if (!brf_icon_bbox(coords, &min_x, &max_x, &min_y, &max_y, &cx, &cy))
+	{
+		*out_pos = vm_vec_new(0.0f, 5000.0f, 0.0f);
+		make_overhead_orient(out_orient);
+		return;
+	}
+
+	// Bounding-circle radius from the centroid, plus a 1 km pad and a 10%
+	// margin so icons don't sit right at the edge.  A circular bound is
+	// independent of the player's screen aspect ratio; matches the
+	// vertical-match strategy in compute_map_camera.
+	float radius_sq_km = 0.0f;
+	for (const auto &c : coords)
+	{
+		float dx = c.x - cx;
+		float dy = c.y - cy;
+		float d2 = dx*dx + dy*dy;
+		if (d2 > radius_sq_km) radius_sq_km = d2;
+	}
+	float padded_radius_m = (fl_sqrt(radius_sq_km) + 1.0f) * 1.1f * 1000.0f;
+
+	// For an overhead camera at height H, FSO's vertical ground extent is
+	// 2 * H * tan(Proj_fov/2), where Proj_fov = Briefing_window_FOV *
+	// PROJ_FOV_FACTOR (see derivation in compute_map_camera).  To fit a
+	// circle of radius R into that view we need H >= R / tan(Proj_fov/2).
+	// On any aspect >= 1:1 the horizontal extent is wider than vertical, so
+	// vertical is the binding constraint.
+	float proj_fov = Briefing_window_FOV * PROJ_FOV_FACTOR;
+	float height = padded_radius_m / fl_tan(proj_fov * 0.5f);
+
+	if (height < 1000.0f)   height = 1000.0f;
+	if (height > 100000.0f) height = 100000.0f;
+
+	*out_pos = brf_map_pos(cx, cy);
+	out_pos->xyz.y += height;
+	make_overhead_orient(out_orient);
+}
+
+// Constants describing X-Wing's native briefing renderer, derived from
+// Mission_XWING95.txt and YOGEME's BriefingFormXwing.cs.
+//   * Pixel position: pixel = ZoomMap * waypoint / 256 (native game math;
+//     YOGEME doubles this for editor display).
+//   * Native VGA briefing map viewport is 103 px tall (BriefingUIPage's
+//     default map page: top=12, bottom=115).
+constexpr float XWING_BRF_RENDER_DIVISOR = 256.0f;
+constexpr float XWING_BRF_MAP_HEIGHT_PX  = 103.0f;
+
+// Visible vertical extent at ZoomMap=Z in meters:
+//   visible_h_m = 1000 * map_height_px / (Z * units_per_km / render_divisor)
+//              = (1000 * 103 * 256 / 160) / Z
+//              = 164800 / Z
+constexpr float XWING_VISIBLE_HEIGHT_M_NUMERATOR =
+	1000.0f * XWING_BRF_MAP_HEIGHT_PX * XWING_BRF_RENDER_DIVISOR / XWING_UNITS_PER_KM;
+
+static void compute_map_camera(vec3d *out_pos, matrix *out_orient, float target_x_km, float target_y_km, short zoom_x, short zoom_y)
+{
+	// Position the overhead camera so FSO's briefing view shows the same
+	// vertical ground extent that the X-Wing native renderer would at this
+	// ZoomMap value.  Derivation:
+	//
+	//   X-Wing visible vertical at ZoomMap Z (meters)
+	//     = XWING_VISIBLE_HEIGHT_M_NUMERATOR / Z          (164800 / Z)
+	//
+	//   FSO Proj_fov = Briefing_window_FOV * PROJ_FOV_FACTOR  (3dsetup.cpp:127-129)
+	//   With Window_scale.y = 1.0 and Matrix_scale.y *= 1/tan(Proj_fov/2)
+	//   (3dsetup.cpp:96-100, 193-196), Proj_fov is effectively the vertical FOV.
+	//   For an overhead camera at height H:  vertical_extent = 2 * H * tan(Proj_fov/2).
+	//
+	// Setting them equal:
+	//   H = (XWING_VISIBLE_HEIGHT_M_NUMERATOR / Z) / (2 * tan(Proj_fov/2))
+	//
+	// Matching the vertical (rather than horizontal) means the constant is
+	// independent of the player's screen aspect ratio.  Side-cropping is
+	// possible on narrow aspects when an X-Wing briefing fills its full
+	// 2.06:1 map area, but nothing above/below the camera ever clips.
+	//
+	// For asymmetric (zoom_x != zoom_y) values we use the smaller, yielding
+	// a higher camera; nothing the more-zoomed axis would have shown gets
+	// cropped (FSO can't reproduce X-Wing's non-square pixels, so under-
+	// zooming is safer than over-zooming).
+	int min_zoom = std::min(std::abs((int)zoom_x), std::abs((int)zoom_y));
+	if (min_zoom < 1)
+		min_zoom = 1;
+
+	float proj_fov = Briefing_window_FOV * PROJ_FOV_FACTOR;
+	float visible_h_m = XWING_VISIBLE_HEIGHT_M_NUMERATOR / static_cast<float>(min_zoom);
+	float height = visible_h_m / (2.0f * fl_tan(proj_fov * 0.5f));
+
+	if (height < 1000.0f)   height = 1000.0f;
+	if (height > 100000.0f) height = 100000.0f;
+
+	*out_pos = brf_map_pos(target_x_km, target_y_km);
+	out_pos->xyz.y += height;
+	make_overhead_orient(out_orient);
+}
+
+// Initialize one brief_icon entry for a given BRF icon at the given coord.
+// All BRF icons map to something: ship-type icons look up their FSO ship class
+// by designation against Parse_objects; everything else (and any orphan ship-
+// type icon) renders as ICON_WAYPOINT.
+static void make_stage_icon(brief_icon *out, const XWMBrfIcon &brf_icon, const XWMBrfCoordinate &coord, int navbuoy_class)
+{
+	memset(out, 0, sizeof(brief_icon));
+
+	int ship_class = navbuoy_class;
+	int team = 0;
+	int icon_type = ICON_WAYPOINT;
+
+	if (xwi_brf_is_ship_type(brf_icon.craftType))
+	{
+		// find an explicitly named parse object
+		auto pobjp = mission_parse_find_parse_object(brf_icon.designation.c_str());
+		if (!pobjp)
+		{
+			// find a parse object from a wing
+			int wingnum = wing_name_lookup(brf_icon.designation.c_str());
+			if (wingnum >= 0)
+			{
+				int idx = find_item_with_field(Parse_objects, &p_object::wingnum, wingnum);
+				if (idx >= 0)
+					pobjp = &Parse_objects[idx];
+			}
+		}
+
+		if (pobjp)
+		{
+			ship_class = pobjp->ship_class;
+			team = pobjp->team;
+			icon_type = xwi_pick_briefing_icon_type(ship_class, brf_icon.numberInWave);
+		}
+		else
+			Warning(LOCATION, "BRF icon '%s' has no matching flight group; rendering as waypoint.", brf_icon.designation.c_str());
+	}
+
+	out->ship_class = ship_class;
+	out->modelnum = -1;
+	out->model_instance_num = -1;
+	out->type = icon_type;
+	out->team = team;
+	out->bitmap_id = -1;
+	out->pos = brf_map_pos(coord.x, coord.y);
+	out->scale_factor = 1.0f;
+}
+
+// Uppercase X-Wing-convention abbreviations for craft types that commonly
+// appear inside BRF TextTag strings ("SHU ALPHA", "TRN ...", "FRT BETA", ...).
+// Used as a tiebreaker when multiple icons are equally near the tag.  Non-
+// craft icon types (mines, planets, etc.) have no entry.
+static SCP_vector<const char *> xwi_brf_craft_keywords(XWMBrfIconType t)
+{
+	switch (t)
+	{
+		case XWMBrfIconType::bi_X_Wing:             return { "X-W" };
+		case XWMBrfIconType::bi_Y_Wing:             return { "Y-W" };
+		case XWMBrfIconType::bi_A_Wing:             return { "A-W" };
+		case XWMBrfIconType::bi_B_Wing:             return { "B-W" };
+		case XWMBrfIconType::bi_TIE_Fighter:        return { "T/F" };
+		case XWMBrfIconType::bi_TIE_Interceptor:    return { "T/I" };
+		case XWMBrfIconType::bi_TIE_Bomber:         return { "T/B" };
+		case XWMBrfIconType::bi_TIE_Advanced:       return { "T/A" };
+		case XWMBrfIconType::bi_Assault_Gunboat:    return { "GUN" };
+		case XWMBrfIconType::bi_Transport:          return { "TRN" };
+		case XWMBrfIconType::bi_Shuttle:            return { "SHU" };
+		case XWMBrfIconType::bi_Tug:                return { "TUG" };
+		case XWMBrfIconType::bi_Container:          return { "CN/" };
+		case XWMBrfIconType::bi_Freighter:          return { "FRT" };
+		case XWMBrfIconType::bi_Calamari_Cruiser:   return { "CRS" };
+		case XWMBrfIconType::bi_Nebulon_B_Frigate:  return { "FRG" };
+		case XWMBrfIconType::bi_Corellian_Corvette: return { "CRV" };
+		case XWMBrfIconType::bi_Star_Destroyer:     return { "STD" };
+		default: return {};
+	}
+}
+
+// Score how well an icon relates to a tag's text.  0 = no relation; higher
+// scores beat lower scores when picking between equally-near candidates.
+// Designation match (specific) outweighs craft-type keyword match (generic).
+static int xwi_score_icon_tag_match(const XWMBrfIcon &icon, const SCP_string &tag_upper)
+{
+	int score = 0;
+
+	if (!icon.designation.empty())
+	{
+		SCP_string desig_upper(icon.designation);
+		for (auto &c : desig_upper)
+			c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+		if (tag_upper.find(desig_upper) != SCP_string::npos)
+			score += 10;
+	}
+
+	for (const char *kw : xwi_brf_craft_keywords(icon.craftType))
+	{
+		if (tag_upper.find(kw) != SCP_string::npos)
+		{
+			score += 5;
+			break;
+		}
+	}
+
+	return score;
+}
+
+// Label the stage icon best matching a tag's 2D position and text.  Geometric
+// nearest is the default, but if other icons within 2x the nearest distance
+// have a designation or craft-type keyword matching the tag text, the highest-
+// scoring one wins (distance breaks ties among equal scores).  If the chosen
+// icon already has a label, allocate an ICON_WAYPOINT stub at the tag's
+// position carrying the label text.
+static void assign_tag_label(brief_stage *bs, float tag_x_km, float tag_y_km,
+	const char *label_text, int navbuoy_class, int max_icons,
+	const std::vector<XWMBrfIcon> &brf_icons)
+{
+	if (bs->num_icons <= 0)
+		return;
+
+	auto tag_pos = brf_map_pos(tag_x_km, tag_y_km);
+
+	// First pass: per-icon squared distance + identify the geometric nearest.
+	SCP_vector<float> d2_per_icon(bs->num_icons, 0.0f);
+	int nearest = 0;
+	float nearest_d2 = std::numeric_limits<float>::infinity();
+	for (int i = 0; i < bs->num_icons; i++)
+	{
+		float dx = bs->icons[i].pos.xyz.x - tag_pos.xyz.x;
+		float dz = bs->icons[i].pos.xyz.z - tag_pos.xyz.z;
+		d2_per_icon[i] = dx*dx + dz*dz;
+		if (d2_per_icon[i] < nearest_d2)
+		{
+			nearest_d2 = d2_per_icon[i];
+			nearest = i;
+		}
+	}
+
+	// Second pass: prefer a text-matching icon among those within 2x the
+	// nearest distance (= 4x in squared form).  Stub icons synthesized by
+	// earlier tags in this stage are past brf_icons.size() and ineligible
+	// for text scoring (no BRF designation/type).
+	int best = nearest;
+	int best_score = 0;
+	float threshold_d2 = nearest_d2 * 4.0f;
+
+	SCP_string tag_upper(label_text);
+	for (auto &c : tag_upper)
+		c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+
+	for (int i = 0; i < bs->num_icons; i++)
+	{
+		if (d2_per_icon[i] > threshold_d2)
+			continue;
+		if (i >= (int)brf_icons.size())
+			continue;
+
+		int score = xwi_score_icon_tag_match(brf_icons[i], tag_upper);
+		// Higher score wins; nearer breaks ties (but only when both scored).
+		if (score > best_score || (score == best_score && score > 0 && d2_per_icon[i] < d2_per_icon[best]))
+		{
+			best_score = score;
+			best = i;
+		}
+	}
+
+	if (bs->icons[best].label[0] == '\0')
+	{
+		strncpy(bs->icons[best].label, label_text, MAX_LABEL_LEN - 1);
+		bs->icons[best].label[MAX_LABEL_LEN - 1] = '\0';
+		return;
+	}
+
+	if (bs->num_icons >= max_icons)
+		return;
+	int stub_idx = bs->num_icons++;
+	auto &stub = bs->icons[stub_idx];
+	memset(&stub, 0, sizeof(brief_icon));
+	stub.ship_class = navbuoy_class;
+	stub.modelnum = -1;
+	stub.model_instance_num = -1;
+	stub.type = ICON_WAYPOINT;
+	stub.bitmap_id = -1;
+	stub.pos = tag_pos;
+	stub.scale_factor = 1.0f;
+	stub.id = Cur_brief_id++;
+	strncpy(stub.label, label_text, MAX_LABEL_LEN - 1);
+	stub.label[MAX_LABEL_LEN - 1] = '\0';
+}
+
+// Ensure the brief_stage has its icons array available.  FRED preallocates;
+// game-side parsing allocates on demand to fit num_icons.
+static void ensure_stage_icons_capacity(brief_stage *bs, int capacity)
+{
+	if (Fred_running || bs->icons != nullptr)
+		return;
+	bs->icons = (brief_icon *)vm_malloc(sizeof(brief_icon) * capacity);
+	Assert(bs->icons != nullptr);
+	memset(bs->icons, 0, sizeof(brief_icon) * capacity);
+}
+
+// Convert an X-Wing BRF caption string into FSO briefing markup.
+//
+//   '$' or '\0'       -> line break.
+//   leading '>'       -> strip; render the rest of the line in yellow ($y).
+//   highlight==1      -> render the run in bright green ($G), unless the line
+//                        is already yellow (yellow wins per the import contract).
+//   0x02 / 0x01       -> inline highlight start/end markers (rare in X-Wing,
+//                        standard in TIE Fighter); honored in addition to the
+//                        parallel highlight[] byte array that LEC missions use.
+static SCP_string xwi_caption_to_fso(const XWMBrfString &src)
+{
+	// Step 1: strip inline 0x02/0x01 codes and merge with the parallel
+	// highlight[] byte array into a per-character bool mask.
+	SCP_string clean;
+	SCP_vector<bool> hl;
+	clean.reserve(src.text.size());
+	hl.reserve(src.text.size());
+	bool inline_hl = false;
+	for (size_t i = 0; i < src.text.size(); i++)
+	{
+		char c = src.text[i];
+		if (c == 0x02) { inline_hl = true;  continue; }
+		if (c == 0x01) { inline_hl = false; continue; }
+		bool array_hl = (i < src.highlight.size()) && (src.highlight[i] != 0);
+		clean.push_back(c);
+		hl.push_back(inline_hl || array_hl);
+	}
+
+	// Step 2 + 3: split on '$' / '\0' and process each line.
+	// FSO color tags need a trailing space — the colorizer eats one whitespace
+	// after the tag, see brief_text_colorize() in missionbriefcommon.cpp.
+	SCP_string out;
+	size_t line_start = 0;
+	auto flush_line = [&](size_t end) {
+		bool yellow = (end > line_start && clean[line_start] == '>');
+		size_t body_start = yellow ? line_start + 1 : line_start;
+		if (yellow) out += "$y{ ";
+
+		size_t i = body_start;
+		while (i < end)
+		{
+			if (hl[i] && !yellow)
+			{
+				size_t run_end = i;
+				while (run_end < end && hl[run_end]) ++run_end;
+				out += "$G{ ";
+				out.append(clean, i, run_end - i);
+				out += " $}";
+				i = run_end;
+			}
+			else
+			{
+				out.push_back(clean[i]);
+				++i;
+			}
+		}
+		if (yellow) out += " $}";
+	};
+
+	for (size_t i = 0; i <= clean.size(); i++)
+	{
+		bool is_break = (i == clean.size()) || clean[i] == '$' || clean[i] == '\0';
+		if (is_break)
+		{
+			flush_line(i);
+			if (i < clean.size()) out.push_back('\n');
+			line_start = i + 1;
+		}
+	}
+	return out;
+}
+
+static void write_placeholder_stage(brief_stage *bs)
+{
+	bs->text = "Prepare for the next X-Wing mission!";
+	strcpy_s(bs->voice, "none.wav");
+	vm_vec_zero(&bs->camera_pos);
+	bs->camera_orient = IDENTITY_MATRIX;
+	bs->camera_time = 500;
+	bs->num_lines = 0;
+	bs->num_icons = 0;
+	bs->flags = 0;
+	bs->formula = Locked_sexp_true;
+	bs->draw_grid = true;
+	bs->grid_color = Color_briefing_grid;
+}
+
 /**
-* Set up xwi briefing based on assumed .brf file in the same folder. If .brf is not there, 
-* just use minimal xwi briefing. 
-*
-* NOTE: This updates the global Briefing struct with all the data necessary to drive the briefing
-*/
+ * Set up xwi briefing based on the parsed .brf file.  Walks the first BRF Map
+ * page (each CaptionText in the page becomes one FSO stage with the camera/
+ * highlight/tag state accumulated since the previous caption), then the BRF
+ * Text pages (each becomes an FSO stage showing a static mission overview).
+ *
+ * The first TitleText event encountered (across all pages) is assigned as the
+ * mission title.
+ *
+ * NOTE: This updates the global Briefings[0] with all the data necessary to
+ * drive the FSO briefing screen.
+ */
 void parse_xwi_briefing(mission *pm, const XWingBriefing *xwBrief)
 {
-	SCP_UNUSED(pm);
-	SCP_UNUSED(xwBrief);
-
 	auto bp = &Briefings[0];
-	bp->num_stages = 1;  // xwing briefings only have one stage
-	auto bs = &bp->stages[0];
+	bp->num_stages = 0;
 
-	/*
-	if (xwBrief != NULL)
+	if (xwBrief == nullptr || xwBrief->icons.empty() ||
+		xwBrief->coordinateSets.empty() || xwBrief->pages.empty())
 	{
-		bs->text = xwBrief->message1;  // this?
-		bs->text = xwBrief->ships[2].designation;  // or this?
-		bs->num_icons = xwBrief->header.icon_count;  // VZTODO is this the right place to store this?
+		bp->num_stages = 1;
+		write_placeholder_stage(&bp->stages[0]);
+		return;
 	}
-	else
-	*/
+
+	// Assign the mission title from the first TitleText event found across all
+	// pages.  If the title text begins with '>' (the X-Wing yellow-centered-line
+	// marker), skip that character.
+	bool title_found = false;
+	for (const auto &page : xwBrief->pages)
 	{
-		bs->text = "Prepare for the next X-Wing mission!";
+		for (const auto &event : page.events)
+		{
+			if (event.opcode == XWMBrfEventOpcode::op_TitleText)
+			{
+				int s_idx = event.params[0];
+				if (s_idx >= 0 && s_idx < (int)xwBrief->strings.size())
+				{
+					const auto &raw = xwBrief->strings[s_idx].text;
+					const char *start = raw.c_str();
+					if (*start == '>')
+						++start;
+					pm->name = start;
+				}
+				title_found = true;
+				break;
+			}
+		}
+		if (title_found)
+			break;
+	}
+
+	int navbuoy_class = xwi_find_navbuoy_ship_class();
+
+	// Step 1: classify pages.  Honor every Text page; honor only the first Map page.
+	std::vector<const XWMBrfPage *> text_pages;
+	const XWMBrfPage *map_page = nullptr;
+	int map_page_count = 0;
+	for (const auto &page : xwBrief->pages)
+	{
+		if (is_brf_map_page(xwBrief, page))
+		{
+			++map_page_count;
+			if (map_page == nullptr)
+				map_page = &page;
+		}
+		else
+		{
+			text_pages.push_back(&page);
+		}
+	}
+	if (map_page_count > 1)
+		Warning(LOCATION, "Briefing has %d map pages; only the first will be used.", map_page_count);
+
+	// Step 2: precompute the static overview camera shared by all Text-page stages.
+	vec3d static_camera_pos;
+	matrix static_camera_orient;
+	compute_static_overview_camera(&static_camera_pos, &static_camera_orient, xwBrief->coordinateSets[0]);
+
+	// Helper: commit one stage with the given parameters.  Returns the next stage
+	// index, or -1 if we hit MAX_BRIEF_STAGES.
+	auto emit_stage = [&](int stage_idx, const SCP_string &text, const vec3d &cam_pos,
+		const matrix &cam_orient, int coord_set_idx, const SCP_set<int> &highlighted,
+		const std::vector<std::tuple<int, short, short>> &text_tags, int camera_time_ms) -> int
+	{
+		if (stage_idx >= MAX_BRIEF_STAGES)
+		{
+			Warning(LOCATION, "Briefing exceeded the FSO stage limit of %d; truncating.", MAX_BRIEF_STAGES);
+			return -1;
+		}
+		auto bs = &bp->stages[stage_idx];
+
+		bs->text = text;
 		strcpy_s(bs->voice, "none.wav");
-		vm_vec_zero(&bs->camera_pos);
-		bs->camera_orient = IDENTITY_MATRIX;
-		bs->camera_time = 500;
-		bs->num_lines = 0;
-		bs->num_icons = 0;
+		bs->camera_pos = cam_pos;
+		bs->camera_orient = cam_orient;
+		bs->camera_time = camera_time_ms;
 		bs->flags = 0;
 		bs->formula = Locked_sexp_true;
+		bs->draw_grid = true;
+		bs->grid_color = Color_briefing_grid;
+		bs->num_lines = 0;
+		bs->num_icons = 0;
+
+		ensure_stage_icons_capacity(bs, MAX_STAGE_ICONS);
+
+		if (coord_set_idx < 0 || coord_set_idx >= (int)xwBrief->coordinateSets.size())
+			coord_set_idx = 0;
+		const auto &coords = xwBrief->coordinateSets[coord_set_idx];
+
+		int icon_limit = std::min((int)xwBrief->icons.size(), MAX_STAGE_ICONS);
+		for (int i = 0; i < icon_limit; i++)
+		{
+			const auto &brf_icon = xwBrief->icons[i];
+			XWMBrfCoordinate fallback_coord{0.0f, 0.0f, 0.0f};
+			const auto &coord = (i < (int)coords.size()) ? coords[i] : fallback_coord;
+			auto &dst = bs->icons[bs->num_icons];
+			make_stage_icon(&dst, brf_icon, coord, navbuoy_class);
+			dst.id = i + 1;
+			if (highlighted.find(i) != highlighted.end())
+				dst.flags |= BI_HIGHLIGHT;
+			++bs->num_icons;
+		}
+		if ((int)xwBrief->icons.size() > MAX_STAGE_ICONS)
+		{
+			Warning(LOCATION, "Briefing stage has %d icons; truncating to MAX_STAGE_ICONS = %d.",
+				(int)xwBrief->icons.size(), MAX_STAGE_ICONS);
+		}
+
+		for (const auto &tag : text_tags)
+		{
+			int tag_idx = std::get<0>(tag);
+			short tx = std::get<1>(tag);
+			short ty = std::get<2>(tag);
+
+			if (tag_idx < 0 || tag_idx >= (int)xwBrief->tags.size())
+				continue;
+			const std::string &tag_text = xwBrief->tags[tag_idx];
+			if (tag_text.empty())
+				continue;
+
+			float tx_km = tx / XWING_UNITS_PER_KM;
+			float ty_km = ty / XWING_UNITS_PER_KM;
+			assign_tag_label(bs, tx_km, ty_km, tag_text.c_str(), navbuoy_class, MAX_STAGE_ICONS, xwBrief->icons);
+		}
+
+		return stage_idx + 1;
+	};
+
+	int stage_idx = 0;
+	SCP_set<int> empty_set;
+	std::vector<std::tuple<int, short, short>> empty_tags;
+
+	// Step 3: emit Map-page stages first (one per CaptionText event).
+	if (map_page != nullptr && stage_idx < MAX_BRIEF_STAGES)
+	{
+		std::vector<int> caption_event_indices;
+		for (int e = 0; e < (int)map_page->events.size(); e++)
+		{
+			auto op = map_page->events[e].opcode;
+			if (op == XWMBrfEventOpcode::op_CaptionText || op == XWMBrfEventOpcode::op_CaptionText2)
+				caption_event_indices.push_back(e);
+		}
+
+		if (caption_event_indices.empty())
+		{
+			Warning(LOCATION, "Map page has no caption events; no map-page stages will be emitted.");
+		}
+		else
+		{
+			// Page-initial camera state: icon centroid, default zoom.
+			int page_coord_set = map_page->coordinateSet;
+			if (page_coord_set < 0 || page_coord_set >= (int)xwBrief->coordinateSets.size())
+				page_coord_set = 0;
+			const auto &page_coords = xwBrief->coordinateSets[page_coord_set];
+
+			float min_x, max_x, min_y, max_y, init_cx, init_cy;
+			if (!brf_icon_bbox(page_coords, &min_x, &max_x, &min_y, &max_y, &init_cx, &init_cy))
+				init_cx = init_cy = 0.0f;
+			const short init_zoom_x = 100;
+			const short init_zoom_y = 100;
+
+			// Camera / highlight state persists across caption windows; tags reset per window.
+			float current_target_x = init_cx;
+			float current_target_y = init_cy;
+			short current_zoom_x  = init_zoom_x;
+			short current_zoom_y  = init_zoom_y;
+			SCP_set<int> highlighted;
+
+			// Track the first MoveMap and ZoomMap of the page (as raw BRF shorts).
+			// X-Wing's loop-back at end-of-page returns the camera to whatever the
+			// FIRST MoveMap established, not to the icon centroid -- so this is the
+			// correct reference for detecting the loop-back event in the final
+			// caption window.  See STARSNDB.BRF page 0: opens with MoveMap(-900,
+			// 670), ends with MoveMap(-900, 670), perfect loop signature.
+			bool   first_move_seen   = false;
+			short  first_move_x_raw  = 0;
+			short  first_move_y_raw  = 0;
+			bool   first_zoom_seen   = false;
+			short  first_zoom_x_raw  = 0;
+			short  first_zoom_y_raw  = 0;
+
+			for (size_t cap = 0; cap < caption_event_indices.size(); cap++)
+			{
+				int window_start = caption_event_indices[cap];
+				int window_end = (cap + 1 < caption_event_indices.size())
+					? caption_event_indices[cap + 1]
+					: (int)map_page->events.size();
+				bool is_final_window = (cap + 1 == caption_event_indices.size());
+
+				std::vector<std::tuple<int, short, short>> text_tags;
+				SCP_string text;
+
+				// Snapshot pre-window camera state for the loop-back rollback case.
+				float pre_target_x = current_target_x;
+				float pre_target_y = current_target_y;
+				short pre_zoom_x  = current_zoom_x;
+				short pre_zoom_y  = current_zoom_y;
+
+				// (is_move, x_or_zoomX, y_or_zoomY)
+				std::vector<std::tuple<bool, short, short>> window_camera_events;
+
+				for (int e = window_start; e < window_end; e++)
+				{
+					const auto &event = map_page->events[e];
+					switch (event.opcode)
+					{
+						case XWMBrfEventOpcode::op_CaptionText:
+						case XWMBrfEventOpcode::op_CaptionText2:
+						{
+							int s_idx = event.params[0];
+							if (s_idx >= 0 && s_idx < (int)xwBrief->strings.size())
+							{
+								if (!text.empty()) text += "\n";
+								text += xwi_caption_to_fso(xwBrief->strings[s_idx]);
+							}
+							break;
+						}
+						case XWMBrfEventOpcode::op_MoveMap:
+							if (!first_move_seen)
+							{
+								first_move_x_raw = event.params[0];
+								first_move_y_raw = event.params[1];
+								first_move_seen = true;
+							}
+							current_target_x = event.params[0] / XWING_UNITS_PER_KM;
+							current_target_y = event.params[1] / XWING_UNITS_PER_KM;
+							window_camera_events.emplace_back(true, event.params[0], event.params[1]);
+							break;
+						case XWMBrfEventOpcode::op_ZoomMap:
+							if (!first_zoom_seen)
+							{
+								first_zoom_x_raw = event.params[0];
+								first_zoom_y_raw = event.params[1];
+								first_zoom_seen = true;
+							}
+							current_zoom_x = event.params[0];
+							current_zoom_y = event.params[1];
+							window_camera_events.emplace_back(false, event.params[0], event.params[1]);
+							break;
+						case XWMBrfEventOpcode::op_ClearFGTags:
+							highlighted.clear();
+							break;
+						case XWMBrfEventOpcode::op_FGTag1:
+						case XWMBrfEventOpcode::op_FGTag2:
+						case XWMBrfEventOpcode::op_FGTag3:
+						case XWMBrfEventOpcode::op_FGTag4:
+							highlighted.insert((int)event.params[0]);
+							break;
+						case XWMBrfEventOpcode::op_ClearTextTags:
+							text_tags.clear();
+							break;
+						case XWMBrfEventOpcode::op_TextTag1:
+						case XWMBrfEventOpcode::op_TextTag2:
+						case XWMBrfEventOpcode::op_TextTag3:
+						case XWMBrfEventOpcode::op_TextTag4:
+							text_tags.emplace_back(event.params[0], event.params[1], event.params[2]);
+							break;
+						default:
+							break;
+					}
+				}
+
+				// Final-window loop-back fixup: if the last camera event in the final
+				// window returns the camera to the position established by the FIRST
+				// camera event of the page (X-Wing briefings loop, so the last
+				// MoveMap typically resets to the opening shot), drop that last
+				// camera event and use the prior state.  Comparing on raw shorts
+				// avoids floating-point fuzz; an exact match is the loop-back
+				// signature.
+				if (is_final_window && window_camera_events.size() >= 2)
+				{
+					bool is_move;
+					short last_x, last_y;
+					std::tie(is_move, last_x, last_y) = window_camera_events.back();
+
+					bool returns_to_initial = false;
+					if (is_move && first_move_seen)
+						returns_to_initial = (last_x == first_move_x_raw && last_y == first_move_y_raw);
+					else if (!is_move && first_zoom_seen)
+						returns_to_initial = (last_x == first_zoom_x_raw && last_y == first_zoom_y_raw);
+
+					if (returns_to_initial)
+					{
+						current_target_x = pre_target_x;
+						current_target_y = pre_target_y;
+						current_zoom_x  = pre_zoom_x;
+						current_zoom_y  = pre_zoom_y;
+						for (size_t i = 0; i + 1 < window_camera_events.size(); i++)
+						{
+							bool im;
+							short cx, cy;
+							std::tie(im, cx, cy) = window_camera_events[i];
+							if (im)
+							{
+								current_target_x = cx / XWING_UNITS_PER_KM;
+								current_target_y = cy / XWING_UNITS_PER_KM;
+							}
+							else
+							{
+								current_zoom_x = cx;
+								current_zoom_y = cy;
+							}
+						}
+					}
+				}
+
+				if (text.empty())
+					text = "(empty caption)";
+
+				vec3d cam_pos;
+				matrix cam_orient;
+				compute_map_camera(&cam_pos, &cam_orient, current_target_x, current_target_y, current_zoom_x, current_zoom_y);
+
+				int next = emit_stage(stage_idx, text, cam_pos, cam_orient, page_coord_set, highlighted, text_tags, 1500);
+				if (next < 0) break;
+				stage_idx = next;
+			}
+		}
+	}
+
+	// Step 4: emit Text-page stages last (static overview view, no highlights).
+	for (const auto *page : text_pages)
+	{
+		// Some BRF authoring tools emit consecutive identical CaptionText events
+		// (LEIA.BRF's Text page fires CaptionText(string 5) at both t=0 and t=1,
+		// which would otherwise concatenate the same paragraph twice in the same
+		// stage).  Dedupe a caption against the most recently appended one.  A
+		// ClearText resets the "last seen" so a re-display after a clear is
+		// honored.
+		SCP_string text;
+		int last_caption_idx = -1;
+		for (const auto &event : page->events)
+		{
+			if (event.opcode == XWMBrfEventOpcode::op_ClearText)
+			{
+				text.clear();
+				last_caption_idx = -1;
+			}
+			else if (event.opcode == XWMBrfEventOpcode::op_CaptionText || event.opcode == XWMBrfEventOpcode::op_CaptionText2)
+			{
+				int s_idx = event.params[0];
+				if (s_idx < 0 || s_idx >= (int)xwBrief->strings.size())
+					continue;
+				if (s_idx == last_caption_idx)
+					continue;
+				if (last_caption_idx >= 0 && xwBrief->strings[s_idx].text == xwBrief->strings[last_caption_idx].text)
+					continue;
+				if (!text.empty()) text += "\n";
+				text += xwi_caption_to_fso(xwBrief->strings[s_idx]);
+				last_caption_idx = s_idx;
+			}
+			// TitleText ignored: FSO renders the mission title separately.
+			// WaitForClick, EndBriefing, None: no-ops.
+			// Map events shouldn't appear in text pages by construction.
+		}
+		if (text.empty())
+			text = "(empty briefing page)";
+
+		int next = emit_stage(stage_idx, text, static_camera_pos, static_camera_orient, 0, empty_set, empty_tags, 500);
+		if (next < 0) break;
+		stage_idx = next;
+	}
+
+	bp->num_stages = stage_idx;
+
+	if (bp->num_stages == 0)
+	{
+		bp->num_stages = 1;
+		write_placeholder_stage(&bp->stages[0]);
 	}
 }
 

--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -703,8 +703,9 @@ void CFREDDoc::OnFileImportXWI()
 		if (ch != NULL)
 			*ch = '\0';
 
-		// assign this as the mission name
-		The_mission.name = filename;
+		// use this as a fallback for the mission title
+		if (The_mission.name.empty())
+			The_mission.name = filename;
 
 		// add new extension
 		strcat_s(filename, ".fs2");


### PR DESCRIPTION
parse_xwi_briefing was previously a stub that wrote a single placeholder stage.  This implementation walks the parsed .BRF and emits a complete FSO briefing:

  - BRF pages are classified into Map vs Text pages by the visibility of the map viewport in the page's referenced viewport set (with a content-based fallback when the viewport set index is out of range).  At most one Map page is honored (extras warn and are skipped); all Text pages are honored.

  - Map page: each CaptionText / CaptionText2 event opens a new FSO stage.  Camera state (MoveMap, ZoomMap), highlights (FGTag*), and text-tag bindings (TextTag*) accumulate per window.  Each stage gets the full icon list with appropriate highlights, plus an overhead camera centered on the page's MoveMap target with height derived from ZoomMap.  Final-stage loop-back detection (X-Wing briefings reset the camera to the opening shot at end of page) elides the redundant final MoveMap.

  - Text pages: each becomes one stage rendering all icons at their canonical positions, with no highlights or labels.  Captions are concatenated; consecutive identical CaptionText events (as LEIA.BRF emits) are deduped.

  - Map-page stages are emitted first, followed by Text-page stages, so the player sees the dynamic dive-in followed by the static overview.

Caption text is converted from BRF markup to FSO color tags by xwi_caption_to_fso, handling $ / NUL line breaks, 0x02 / 0x01 inline highlight markers, the parallel highlight[] byte array, and >-prefix yellow lines.

TextTag-to-icon labeling prefers the icon whose designation or craft-type abbreviation appears in the tag text, falling back to the geometric nearest icon when nothing scores.  If the chosen icon already carries a label this stage, a stub ICON_WAYPOINT is synthesized at the tag position.

Camera derivation matches X-Wing's native VGA briefing renderer (103 px map viewport, pixel = ZoomMap * waypoint / 256) so the FSO view shows the same vertical ground extent as the original at the player's Briefing_window_FOV.  Static-overview camera fits the icon bounding sphere with a 1 km pad and 10% margin.

To support the variable-length tail of the .BRF file, read_file_bytes now returns the file length, which is passed through to XWingBriefing::load.

The first TitleText event encountered (across all pages) is assigned as the mission title; freddoc.cpp's batch importer now only falls back to the filename when no title was found.

~~Depends on #56; in draft until that is merged.~~